### PR TITLE
Call `createClientWithAutoPoll` directly from `createClient` to avoid undefined `this` in strict mode with destructured require

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -9,7 +9,7 @@ import { LogLevel } from "configcat-common/lib/index";
  * @param options - Options for Auto Polling
  */
 export function createClient(sdkKey: string, options?: INodeAutoPollOptions): IConfigCatClient {
-    return this.createClientWithAutoPoll(sdkKey, options);
+    return createClientWithAutoPoll(sdkKey, options);
 }
 
 /**


### PR DESCRIPTION
### Describe the purpose of your pull request

When calling `createClient` from Node using a destructured `require()` statement, `createClient` will throw the following error:

`TypeError: Cannot read property 'createClientWithAutoPoll' of undefined`

Due to TypeScript invoking `"strict mode";` for the compiled code, `this` is undefined in `createClient` only when invoked directly (because of the destructuring, in this case). There's a few different ways to work around this, and so it shouldn't block anyone, but this change should fix it for that case.

I tested the fix with Node 14 (plain JavaScript) and TypeScript (via `ts-node`). I tried multiple styles of imports and didn't have any issues.

### Reproduction

I reproduced this issue by creating a `test.js` file in the repo and executing it with `node test.js`.

```javascript
const {createClient} = require('./lib/client');
const client = createClient("SDKKEY");
```

### Requirement checklist (only if applicable)

- [ ] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions. (See notes above, but I can test with other versions of Node if needed.)
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
