### PR TITLE
Remove X-ConfigCat-UserAgent header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "configcat-node",
-  "version": "6.10.0",
+  "version": "7.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "configcat-node",
-      "version": "6.10.0",
+      "version": "7.0.0",
       "license": "MIT",
       "dependencies": {
-        "configcat-common": "^5.2.0",
+        "configcat-common": "^6.0.0",
         "got": "^9.6.0",
         "tunnel": "0.0.6"
       },
@@ -1648,9 +1648,9 @@
       }
     },
     "node_modules/configcat-common": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/configcat-common/-/configcat-common-5.2.0.tgz",
-      "integrity": "sha512-dJDfZ0FB+HMie2+ebMPDGlX0zXs6yoy0FdW/WItsw9JxnYn2l6MHSev724800rs4AcmHbUXL1KlxJ+gOHR+3iw=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/configcat-common/-/configcat-common-6.0.0.tgz",
+      "integrity": "sha512-C/lCeTKiFk9kPElRF3f4zIkvVCLKgPJuzrKbIMHCru89mvfH5t4//hZ9TW8wPJOAje6xB6ZALutDiIxggwUvWA=="
     },
     "node_modules/convert-source-map": {
       "version": "1.8.0",
@@ -8848,9 +8848,9 @@
       }
     },
     "configcat-common": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/configcat-common/-/configcat-common-5.2.0.tgz",
-      "integrity": "sha512-dJDfZ0FB+HMie2+ebMPDGlX0zXs6yoy0FdW/WItsw9JxnYn2l6MHSev724800rs4AcmHbUXL1KlxJ+gOHR+3iw=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/configcat-common/-/configcat-common-6.0.0.tgz",
+      "integrity": "sha512-C/lCeTKiFk9kPElRF3f4zIkvVCLKgPJuzrKbIMHCru89mvfH5t4//hZ9TW8wPJOAje6xB6ZALutDiIxggwUvWA=="
     },
     "convert-source-map": {
       "version": "1.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "configcat-node",
-  "version": "6.10.0",
+  "version": "7.0.0",
   "description": "Official ConfigCat SDK to help you access your feature flags from a Node.js application.",
   "main": "lib/client.js",
   "types": "lib/client.d.ts",
@@ -26,7 +26,7 @@
   "license": "MIT",
   "homepage": "https://configcat.com",
   "dependencies": {
-    "configcat-common": "^5.2.0",
+    "configcat-common": "^6.0.0",
     "got": "^9.6.0",
     "tunnel": "0.0.6"
   },

--- a/src/config-fetcher.ts
+++ b/src/config-fetcher.ts
@@ -31,7 +31,6 @@ export class HttpConfigFetcher implements IConfigFetcher {
             agent,
             headers: {
                 "User-Agent": options.clientVersion,
-                "X-ConfigCat-UserAgent": options.clientVersion,
                 "If-None-Match": (lastEtag) ? lastEtag : undefined
             }
         }).then((response) => {


### PR DESCRIPTION
### Describe the purpose of your pull request

This PR removes the `X-ConfigCat-UserAgent` request header. The SDK version is now a query param in the fetch URL.

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
